### PR TITLE
chore: release v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "es-fluent-derive",
  "fluent-bundle",
@@ -517,7 +517,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-build"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cargo_metadata",
  "es-fluent-generate",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cargo_metadata",
  "clap",
@@ -551,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bon",
  "darling",
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-derive"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "darling",
  "es-fluent-core",
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-generate"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "es-fluent-core",
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-sc-parser"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bon",
  "darling",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ license = "MIT OR Apache-2.0"
 publish = true
 readme = "README.md"
 repository = "https://github.com/stayhydated/es-fluent"
-version = "0.1.0"
+version = "0.1.1"
 
 [workspace.dependencies]
 anyhow = "1.0.98"
@@ -33,12 +33,12 @@ crossterm = "0.29.0"
 darling = "0.20.11"
 derive_more = "2.0.1"
 env_logger = "0.11"
-es-fluent = { default-features = false, path = "crates/es-fluent", version = "0.1.0" }
+es-fluent = { default-features = false, path = "crates/es-fluent", version = "0.1.1" }
 es-fluent-build = { path = "crates/es-fluent-build" }
-es-fluent-core = { default-features = false, path = "crates/es-fluent-core", version = "0.1.0" }
-es-fluent-derive = { path = "crates/es-fluent-derive", version = "0.1.0" }
-es-fluent-generate = { path = "crates/es-fluent-generate", version = "0.1.0" }
-es-fluent-sc-parser = { path = "crates/es-fluent-sc-parser", version = "0.1.0" }
+es-fluent-core = { default-features = false, path = "crates/es-fluent-core", version = "0.1.1" }
+es-fluent-derive = { path = "crates/es-fluent-derive", version = "0.1.1" }
+es-fluent-generate = { path = "crates/es-fluent-generate", version = "0.1.1" }
+es-fluent-sc-parser = { path = "crates/es-fluent-sc-parser", version = "0.1.1" }
 fluent-bundle = "0.15.3"
 fluent-syntax = "0.11.1"
 garde = "0.22.0"

--- a/crates/es-fluent-build/CHANGELOG.md
+++ b/crates/es-fluent-build/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/stayhydated/es-fluent/compare/es-fluent-build-v0.1.0...es-fluent-build-v0.1.1) - 2025-07-07
+
+### Other
+
+- release v0.1.0
+- .
+
 ## [0.1.0](https://github.com/stayhydated/es-fluent/releases/tag/es-fluent-build-v0.1.0) - 2025-07-03
 
 ### Other

--- a/crates/es-fluent-cli/CHANGELOG.md
+++ b/crates/es-fluent-cli/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/stayhydated/es-fluent/compare/es-fluent-cli-v0.1.0...es-fluent-cli-v0.1.1) - 2025-07-07
+
+### Other
+
+- release v0.1.0
+- .
+
 ## [0.1.0](https://github.com/stayhydated/es-fluent/releases/tag/es-fluent-cli-v0.1.0) - 2025-07-03
 
 ### Other

--- a/crates/es-fluent-core/CHANGELOG.md
+++ b/crates/es-fluent-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/stayhydated/es-fluent/compare/es-fluent-core-v0.1.0...es-fluent-core-v0.1.1) - 2025-07-07
+
+### Other
+
+- release v0.1.0
+
 ## [0.1.0](https://github.com/stayhydated/es-fluent/releases/tag/es-fluent-core-v0.1.0) - 2025-07-03
 
 ### Other

--- a/crates/es-fluent-derive/CHANGELOG.md
+++ b/crates/es-fluent-derive/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/stayhydated/es-fluent/compare/es-fluent-derive-v0.1.0...es-fluent-derive-v0.1.1) - 2025-07-07
+
+### Other
+
+- release v0.1.0
+
 ## [0.1.0](https://github.com/stayhydated/es-fluent/releases/tag/es-fluent-derive-v0.1.0) - 2025-07-03
 
 ### Other

--- a/crates/es-fluent-generate/CHANGELOG.md
+++ b/crates/es-fluent-generate/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/stayhydated/es-fluent/compare/es-fluent-generate-v0.1.0...es-fluent-generate-v0.1.1) - 2025-07-07
+
+### Other
+
+- release v0.1.0
+
 ## [0.1.0](https://github.com/stayhydated/es-fluent/releases/tag/es-fluent-generate-v0.1.0) - 2025-07-03
 
 ### Other

--- a/crates/es-fluent-sc-parser/CHANGELOG.md
+++ b/crates/es-fluent-sc-parser/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/stayhydated/es-fluent/compare/es-fluent-sc-parser-v0.1.0...es-fluent-sc-parser-v0.1.1) - 2025-07-07
+
+### Other
+
+- release v0.1.0
+
 ## [0.1.0](https://github.com/stayhydated/es-fluent/releases/tag/es-fluent-sc-parser-v0.1.0) - 2025-07-03
 
 ### Other

--- a/crates/es-fluent/CHANGELOG.md
+++ b/crates/es-fluent/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/stayhydated/es-fluent/compare/es-fluent-v0.1.0...es-fluent-v0.1.1) - 2025-07-07
+
+### Other
+
+- Merge pull request #1 from stayhydated/release-plz-2025-07-03T17-49-32Z
+- Update README.md
+
 ## [0.1.0](https://github.com/stayhydated/es-fluent/releases/tag/es-fluent-v0.1.0) - 2025-07-03
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `es-fluent-core`: 0.1.0 -> 0.1.1
* `es-fluent-derive`: 0.1.0 -> 0.1.1
* `es-fluent`: 0.1.0 -> 0.1.1
* `es-fluent-generate`: 0.1.0 -> 0.1.1
* `es-fluent-sc-parser`: 0.1.0 -> 0.1.1
* `es-fluent-build`: 0.1.0 -> 0.1.1
* `es-fluent-cli`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `es-fluent-core`

<blockquote>

## [0.1.1](https://github.com/stayhydated/es-fluent/compare/es-fluent-core-v0.1.0...es-fluent-core-v0.1.1) - 2025-07-07

### Other

- release v0.1.0
</blockquote>

## `es-fluent-derive`

<blockquote>

## [0.1.1](https://github.com/stayhydated/es-fluent/compare/es-fluent-derive-v0.1.0...es-fluent-derive-v0.1.1) - 2025-07-07

### Other

- release v0.1.0
</blockquote>

## `es-fluent`

<blockquote>

## [0.1.1](https://github.com/stayhydated/es-fluent/compare/es-fluent-v0.1.0...es-fluent-v0.1.1) - 2025-07-07

### Other

- Merge pull request #1 from stayhydated/release-plz-2025-07-03T17-49-32Z
- Update README.md
</blockquote>

## `es-fluent-generate`

<blockquote>

## [0.1.1](https://github.com/stayhydated/es-fluent/compare/es-fluent-generate-v0.1.0...es-fluent-generate-v0.1.1) - 2025-07-07

### Other

- release v0.1.0
</blockquote>

## `es-fluent-sc-parser`

<blockquote>

## [0.1.1](https://github.com/stayhydated/es-fluent/compare/es-fluent-sc-parser-v0.1.0...es-fluent-sc-parser-v0.1.1) - 2025-07-07

### Other

- release v0.1.0
</blockquote>

## `es-fluent-build`

<blockquote>

## [0.1.1](https://github.com/stayhydated/es-fluent/compare/es-fluent-build-v0.1.0...es-fluent-build-v0.1.1) - 2025-07-07

### Other

- release v0.1.0
- .
</blockquote>

## `es-fluent-cli`

<blockquote>

## [0.1.1](https://github.com/stayhydated/es-fluent/compare/es-fluent-cli-v0.1.0...es-fluent-cli-v0.1.1) - 2025-07-07

### Other

- release v0.1.0
- .
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).