### PR TITLE
chore: release

### DIFF
--- a/crates/es-fluent-manager-bevy/CHANGELOG.md
+++ b/crates/es-fluent-manager-bevy/CHANGELOG.md
@@ -1,0 +1,57 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.17.0](https://github.com/stayhydated/es-fluent/releases/tag/es-fluent-manager-bevy-v0.17.0) - 2025-10-12
+
+### Other
+
+- singleton -> embedded (es-fluent-manager)
+- .
+- Update README.md
+- .
+- .
+- .
+- .
+- impl base iced + make bevy manager hold CurrentLanguageId
+- add shared lib in examples
+- .
+- .
+- .
+- Update README.md
+- unreviewed docs + reduce deps to import from users
+- .
+- reduce code needed to be declared from consumers
+- .
+- migrate code from bevy 0.16 to 0.17
+- .
+- make clippy happy
+- fmt
+- simplify further
+- bevy explorations
+- .
+- .
+- .
+- use rust-embed for singleton impl
+- .
+- .
+- .
+- fmt
+- .
+- Update lib.rs
+- .
+- rough draft
+- use add_observer
+- add convenience register_i18n_module macro
+- add <https://github.com/crate-ci/typos>
+- .
+- .
+- kinda broken but works
+- Update README.md
+- Update README.md
+- .

--- a/crates/es-fluent-manager-embedded/CHANGELOG.md
+++ b/crates/es-fluent-manager-embedded/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/stayhydated/es-fluent/releases/tag/es-fluent-manager-embedded-v0.2.0) - 2025-10-12
+
+### Other
+
+- singleton -> embedded (es-fluent-manager)
+- .
+- .
+- .
+- .
+- Update README.md
+- add <https://github.com/crate-ci/typos>
+- Update README.md
+- Update README.md
+- .

--- a/crates/es-fluent-manager-macros/CHANGELOG.md
+++ b/crates/es-fluent-manager-macros/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/stayhydated/es-fluent/releases/tag/es-fluent-manager-macros-v0.2.0) - 2025-10-12
+
+### Other
+
+- singleton -> embedded (es-fluent-manager)
+- .
+- .
+- .
+- .
+- .
+- .
+- Update README.md
+- unreviewed docs + reduce deps to import from users
+- make clippy happy
+- .
+- this kinda works, but it's fk horrible
+- .
+- .
+- .
+- use rust-embed for singleton impl
+- .
+- rough draft
+- add convenience register_i18n_module macro
+- add <https://github.com/crate-ci/typos>
+- Update README.md
+- Update README.md
+- .

--- a/crates/es-fluent-toml/CHANGELOG.md
+++ b/crates/es-fluent-toml/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/stayhydated/es-fluent/releases/tag/es-fluent-toml-v0.2.0) - 2025-10-12
+
+### Other
+
+- singleton -> embedded (es-fluent-manager)
+- .
+- .
+- .
+- .
+- .
+- .
+- Update README.md
+- unreviewed docs + reduce deps to import from users
+- .
+- .
+- .
+- .
+- use rust-embed for singleton impl
+- .
+- Update lib.rs
+- Update lib.rs
+- get rid of `i18n-config`
+- add <https://github.com/crate-ci/typos>
+- Update README.md
+- Update README.md
+- .


### PR DESCRIPTION



## 🤖 New release

* `es-fluent-toml`: 0.2.0
* `es-fluent-manager-macros`: 0.2.0
* `es-fluent-manager-embedded`: 0.2.0
* `es-fluent-manager-bevy`: 0.17.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `es-fluent-toml`

<blockquote>

## [0.2.0](https://github.com/stayhydated/es-fluent/releases/tag/es-fluent-toml-v0.2.0) - 2025-10-12

### Other

- singleton -> embedded (es-fluent-manager)
- .
- .
- .
- .
- .
- .
- Update README.md
- unreviewed docs + reduce deps to import from users
- .
- .
- .
- .
- use rust-embed for singleton impl
- .
- Update lib.rs
- Update lib.rs
- get rid of `i18n-config`
- add <https://github.com/crate-ci/typos>
- Update README.md
- Update README.md
- .
</blockquote>

## `es-fluent-manager-macros`

<blockquote>

## [0.2.0](https://github.com/stayhydated/es-fluent/releases/tag/es-fluent-manager-macros-v0.2.0) - 2025-10-12

### Other

- singleton -> embedded (es-fluent-manager)
- .
- .
- .
- .
- .
- .
- Update README.md
- unreviewed docs + reduce deps to import from users
- make clippy happy
- .
- this kinda works, but it's fk horrible
- .
- .
- .
- use rust-embed for singleton impl
- .
- rough draft
- add convenience register_i18n_module macro
- add <https://github.com/crate-ci/typos>
- Update README.md
- Update README.md
- .
</blockquote>

## `es-fluent-manager-embedded`

<blockquote>

## [0.2.0](https://github.com/stayhydated/es-fluent/releases/tag/es-fluent-manager-embedded-v0.2.0) - 2025-10-12

### Other

- singleton -> embedded (es-fluent-manager)
- .
- .
- .
- .
- Update README.md
- add <https://github.com/crate-ci/typos>
- Update README.md
- Update README.md
- .
</blockquote>

## `es-fluent-manager-bevy`

<blockquote>

## [0.17.0](https://github.com/stayhydated/es-fluent/releases/tag/es-fluent-manager-bevy-v0.17.0) - 2025-10-12

### Other

- singleton -> embedded (es-fluent-manager)
- .
- Update README.md
- .
- .
- .
- .
- impl base iced + make bevy manager hold CurrentLanguageId
- add shared lib in examples
- .
- .
- .
- Update README.md
- unreviewed docs + reduce deps to import from users
- .
- reduce code needed to be declared from consumers
- .
- migrate code from bevy 0.16 to 0.17
- .
- make clippy happy
- fmt
- simplify further
- bevy explorations
- .
- .
- .
- use rust-embed for singleton impl
- .
- .
- .
- fmt
- .
- Update lib.rs
- .
- rough draft
- use add_observer
- add convenience register_i18n_module macro
- add <https://github.com/crate-ci/typos>
- .
- .
- kinda broken but works
- Update README.md
- Update README.md
- .
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).