### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,7 +998,7 @@ dependencies = [
 
 [[package]]
 name = "bevy-example"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "bevy",
  "es-fluent",
@@ -3346,7 +3346,7 @@ dependencies = [
 
 [[package]]
 name = "cosmic-example"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "es-fluent",
  "es-fluent-build",
@@ -4323,7 +4323,7 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "es-fluent"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "es-fluent-derive",
@@ -4339,7 +4339,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-build"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "cargo_metadata",
  "es-fluent-generate",
@@ -4352,7 +4352,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-cli"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "cargo_metadata",
  "clap",
@@ -4373,7 +4373,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-core"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "bon",
  "darling 0.20.11",
@@ -4393,7 +4393,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-derive"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "darling 0.20.11",
  "es-fluent-core",
@@ -4408,7 +4408,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-generate"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "clap",
  "es-fluent-core",
@@ -4423,7 +4423,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-manager-bevy"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "bevy",
  "es-fluent",
@@ -4439,7 +4439,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-manager-core"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "fluent-bundle",
@@ -4452,7 +4452,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-manager-embedded"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "es-fluent",
  "es-fluent-manager-core",
@@ -4465,7 +4465,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-manager-macros"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "es-fluent-manager-core",
  "es-fluent-toml",
@@ -4477,7 +4477,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-sc-parser"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "bon",
  "darling 0.20.11",
@@ -4493,7 +4493,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-toml"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "serde",
  "tempfile",
@@ -4560,7 +4560,7 @@ dependencies = [
 
 [[package]]
 name = "example-shared-lib"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "bevy",
  "es-fluent",
@@ -4688,7 +4688,7 @@ checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
 
 [[package]]
 name = "first-example"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "es-fluent",
  "es-fluent-build",
@@ -5590,7 +5590,7 @@ dependencies = [
 
 [[package]]
 name = "gpui-example"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "es-fluent",
  "es-fluent-build",
@@ -6085,7 +6085,7 @@ dependencies = [
 
 [[package]]
 name = "iced-example"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "es-fluent",
  "es-fluent-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ publish = true
 readme = "README.md"
 repository = "https://github.com/stayhydated/es-fluent"
 rust-version = "1.88"
-version = "0.2.3"
+version = "0.2.4"
 
 [workspace.dependencies]
 anyhow = "1.0.98"
@@ -44,17 +44,17 @@ crossterm = "0.29.0"
 darling = "0.20.11"
 derive_more = "2.0.1"
 env_logger = "0.11"
-es-fluent = { default-features = false, path = "crates/es-fluent", version = "0.2.3" }
+es-fluent = { default-features = false, path = "crates/es-fluent", version = "0.2.4" }
 es-fluent-build = { path = "crates/es-fluent-build" }
-es-fluent-core = { default-features = false, path = "crates/es-fluent-core", version = "0.2.3" }
-es-fluent-derive = { path = "crates/es-fluent-derive", version = "0.2.3" }
-es-fluent-generate = { path = "crates/es-fluent-generate", version = "0.2.3" }
-es-fluent-manager-bevy = { path = "crates/es-fluent-manager-bevy", version = "0.17.3" }
-es-fluent-manager-core = { path = "crates/es-fluent-manager-core", version = "0.2.3" }
-es-fluent-manager-embedded = { path = "crates/es-fluent-manager-embedded", version = "0.2.3" }
-es-fluent-manager-macros = { path = "crates/es-fluent-manager-macros", version = "0.2.3" }
-es-fluent-sc-parser = { path = "crates/es-fluent-sc-parser", version = "0.2.3" }
-es-fluent-toml = { path = "crates/es-fluent-toml", version = "0.2.3" }
+es-fluent-core = { default-features = false, path = "crates/es-fluent-core", version = "0.2.4" }
+es-fluent-derive = { path = "crates/es-fluent-derive", version = "0.2.4" }
+es-fluent-generate = { path = "crates/es-fluent-generate", version = "0.2.4" }
+es-fluent-manager-bevy = { path = "crates/es-fluent-manager-bevy", version = "0.17.4" }
+es-fluent-manager-core = { path = "crates/es-fluent-manager-core", version = "0.2.4" }
+es-fluent-manager-embedded = { path = "crates/es-fluent-manager-embedded", version = "0.2.4" }
+es-fluent-manager-macros = { path = "crates/es-fluent-manager-macros", version = "0.2.4" }
+es-fluent-sc-parser = { path = "crates/es-fluent-sc-parser", version = "0.2.4" }
+es-fluent-toml = { path = "crates/es-fluent-toml", version = "0.2.4" }
 fluent = { version = "0.17.0" }
 fluent-bundle = "0.16.0"
 fluent-syntax = "0.11.1"

--- a/crates/es-fluent-core/CHANGELOG.md
+++ b/crates/es-fluent-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4](https://github.com/stayhydated/es-fluent/compare/es-fluent-core-v0.2.3...es-fluent-core-v0.2.4) - 2025-10-17
+
+### Other
+
+- support struct_tuple
+
 ## [0.2.3](https://github.com/stayhydated/es-fluent/compare/es-fluent-core-v0.2.2...es-fluent-core-v0.2.3) - 2025-10-14
 
 ### Other

--- a/crates/es-fluent-derive/CHANGELOG.md
+++ b/crates/es-fluent-derive/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4](https://github.com/stayhydated/es-fluent/compare/es-fluent-derive-v0.2.3...es-fluent-derive-v0.2.4) - 2025-10-17
+
+### Other
+
+- support struct_tuple
+
 ## [0.1.3](https://github.com/stayhydated/es-fluent/compare/es-fluent-derive-v0.1.2...es-fluent-derive-v0.1.3) - 2025-07-22
 
 ### Other

--- a/crates/es-fluent-manager-bevy/CHANGELOG.md
+++ b/crates/es-fluent-manager-bevy/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.4](https://github.com/stayhydated/es-fluent/compare/es-fluent-manager-bevy-v0.17.3...es-fluent-manager-bevy-v0.17.4) - 2025-10-17
+
+### Other
+
+- updated the following local packages: es-fluent-manager-core, es-fluent, es-fluent-manager-macros
+
 ## [0.17.3](https://github.com/stayhydated/es-fluent/compare/es-fluent-manager-bevy-v0.17.2...es-fluent-manager-bevy-v0.17.3) - 2025-10-14
 
 ### Other

--- a/crates/es-fluent-manager-bevy/Cargo.toml
+++ b/crates/es-fluent-manager-bevy/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 license.workspace = true
 publish.workspace = true
 repository.workspace = true
-version = "0.17.3"
+version = "0.17.4"
 
 [dependencies]
 bevy = { features = [ "file_watcher" ], workspace = true }

--- a/crates/es-fluent/CHANGELOG.md
+++ b/crates/es-fluent/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4](https://github.com/stayhydated/es-fluent/compare/es-fluent-v0.2.3...es-fluent-v0.2.4) - 2025-10-17
+
+### Other
+
+- mention EsFluentKv
+- update first-example
+- support struct_tuple
+
 ## [0.2.3](https://github.com/stayhydated/es-fluent/compare/es-fluent-v0.2.2...es-fluent-v0.2.3) - 2025-10-14
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `es-fluent-core`: 0.2.3 -> 0.2.4
* `es-fluent-derive`: 0.2.3 -> 0.2.4
* `es-fluent-manager-core`: 0.2.3 -> 0.2.4
* `es-fluent`: 0.2.3 -> 0.2.4
* `es-fluent-toml`: 0.2.3 -> 0.2.4
* `es-fluent-generate`: 0.2.3 -> 0.2.4
* `es-fluent-sc-parser`: 0.2.3 -> 0.2.4
* `es-fluent-build`: 0.2.3 -> 0.2.4
* `es-fluent-cli`: 0.2.3 -> 0.2.4
* `es-fluent-manager-macros`: 0.2.3 -> 0.2.4
* `es-fluent-manager-embedded`: 0.2.3 -> 0.2.4
* `es-fluent-manager-bevy`: 0.17.3 -> 0.17.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `es-fluent-core`

<blockquote>

## [0.2.4](https://github.com/stayhydated/es-fluent/compare/es-fluent-core-v0.2.3...es-fluent-core-v0.2.4) - 2025-10-17

### Other

- support struct_tuple
</blockquote>

## `es-fluent-derive`

<blockquote>

## [0.2.4](https://github.com/stayhydated/es-fluent/compare/es-fluent-derive-v0.2.3...es-fluent-derive-v0.2.4) - 2025-10-17

### Other

- support struct_tuple
</blockquote>

## `es-fluent-manager-core`

<blockquote>

## [0.2.1](https://github.com/stayhydated/es-fluent/compare/es-fluent-manager-core-v0.2.0...es-fluent-manager-core-v0.2.1) - 2025-10-12

### Other

- .
- add descriptions
</blockquote>

## `es-fluent`

<blockquote>

## [0.2.4](https://github.com/stayhydated/es-fluent/compare/es-fluent-v0.2.3...es-fluent-v0.2.4) - 2025-10-17

### Other

- mention EsFluentKv
- update first-example
- support struct_tuple
</blockquote>

## `es-fluent-toml`

<blockquote>

## [0.2.1](https://github.com/stayhydated/es-fluent/compare/es-fluent-toml-v0.2.0...es-fluent-toml-v0.2.1) - 2025-10-12

### Other

- .
</blockquote>

## `es-fluent-generate`

<blockquote>

## [0.1.1](https://github.com/stayhydated/es-fluent/compare/es-fluent-generate-v0.1.0...es-fluent-generate-v0.1.1) - 2025-07-15

### Other

- .
- place "this" variant first
- release v0.1.0
</blockquote>

## `es-fluent-sc-parser`

<blockquote>

## [0.2.1](https://github.com/stayhydated/es-fluent/compare/es-fluent-sc-parser-v0.2.0...es-fluent-sc-parser-v0.2.1) - 2025-10-12

### Other

- make clippy happy
</blockquote>

## `es-fluent-build`

<blockquote>

## [0.1.0](https://github.com/stayhydated/es-fluent/releases/tag/es-fluent-build-v0.1.0) - 2025-07-03

### Other

- .
</blockquote>

## `es-fluent-cli`

<blockquote>

## [0.1.2](https://github.com/stayhydated/es-fluent/compare/es-fluent-cli-v0.1.1...es-fluent-cli-v0.1.2) - 2025-07-15

### Other

- update Cargo.lock dependencies
</blockquote>

## `es-fluent-manager-macros`

<blockquote>

## [0.2.1](https://github.com/stayhydated/es-fluent/compare/es-fluent-manager-macros-v0.2.0...es-fluent-manager-macros-v0.2.1) - 2025-10-12

### Other

- make clippy happy
- .
</blockquote>

## `es-fluent-manager-embedded`

<blockquote>

## [0.2.1](https://github.com/stayhydated/es-fluent/compare/es-fluent-manager-embedded-v0.2.0...es-fluent-manager-embedded-v0.2.1) - 2025-10-12

### Other

- .
</blockquote>

## `es-fluent-manager-bevy`

<blockquote>

## [0.17.4](https://github.com/stayhydated/es-fluent/compare/es-fluent-manager-bevy-v0.17.3...es-fluent-manager-bevy-v0.17.4) - 2025-10-17

### Other

- updated the following local packages: es-fluent-manager-core, es-fluent, es-fluent-manager-macros
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).