### PR TITLE
chore: release v0.2.5

### DIFF
--- a/crates/es-fluent-lang-macro/CHANGELOG.md
+++ b/crates/es-fluent-lang-macro/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.5](https://github.com/stayhydated/es-fluent/releases/tag/es-fluent-lang-macro-v0.2.5) - 2025-10-20
+
+### Fixed
+
+- fix ci again lmao
+- fix readme linking
+
+### Other
+
+- add rust-version.workspace
+- .
+- combine ci
+- .
+- machete
+- .
+- update doc
+- fmt
+- wip
+- update examples
+- reject script, region or variants
+- wip
+- wip

--- a/crates/es-fluent-lang/CHANGELOG.md
+++ b/crates/es-fluent-lang/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.5](https://github.com/stayhydated/es-fluent/releases/tag/es-fluent-lang-v0.2.5) - 2025-10-20
+
+### Fixed
+
+- fix ci again lmao
+- fix readme linking
+
+### Other
+
+- .
+- .
+- .
+- update doc
+- fmt
+- wip
+- generate es-fluent-lang
+- update examples
+- reject script, region or variants
+- wip
+- wip


### PR DESCRIPTION



## 🤖 New release

* `es-fluent-lang-macro`: 0.2.5
* `es-fluent-lang`: 0.2.5

<details><summary><i><b>Changelog</b></i></summary><p>

## `es-fluent-lang-macro`

<blockquote>

## [0.2.5](https://github.com/stayhydated/es-fluent/releases/tag/es-fluent-lang-macro-v0.2.5) - 2025-10-20

### Fixed

- fix ci again lmao
- fix readme linking

### Other

- add rust-version.workspace
- .
- combine ci
- .
- machete
- .
- update doc
- fmt
- wip
- update examples
- reject script, region or variants
- wip
- wip
</blockquote>

## `es-fluent-lang`

<blockquote>

## [0.2.5](https://github.com/stayhydated/es-fluent/releases/tag/es-fluent-lang-v0.2.5) - 2025-10-20

### Fixed

- fix ci again lmao
- fix readme linking

### Other

- .
- .
- .
- update doc
- fmt
- wip
- generate es-fluent-lang
- update examples
- reject script, region or variants
- wip
- wip
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).