### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,7 +998,7 @@ dependencies = [
 
 [[package]]
 name = "bevy-example"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "bevy",
  "es-fluent",
@@ -3346,7 +3346,7 @@ dependencies = [
 
 [[package]]
 name = "cosmic-example"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "es-fluent",
  "es-fluent-build",
@@ -4323,7 +4323,7 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "es-fluent"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "es-fluent-derive",
  "es-fluent-manager-core",
@@ -4336,7 +4336,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-build"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "cargo_metadata",
  "es-fluent-generate",
@@ -4348,7 +4348,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-cli"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "cargo_metadata",
  "clap",
@@ -4368,7 +4368,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-core"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "bon",
  "darling 0.20.11",
@@ -4388,7 +4388,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-derive"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "darling 0.20.11",
  "es-fluent-core",
@@ -4403,7 +4403,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-generate"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "clap",
  "es-fluent-core",
@@ -4418,7 +4418,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-lang"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "es-fluent-lang-macro",
  "es-fluent-manager-core",
@@ -4430,7 +4430,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-lang-macro"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "es-fluent-toml",
  "heck 0.5.0",
@@ -4443,7 +4443,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-manager-bevy"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "bevy",
  "es-fluent",
@@ -4458,7 +4458,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-manager-core"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "fluent-bundle",
@@ -4471,7 +4471,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-manager-embedded"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "es-fluent",
  "es-fluent-manager-core",
@@ -4482,7 +4482,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-manager-macros"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "es-fluent-toml",
  "heck 0.5.0",
@@ -4493,7 +4493,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-sc-parser"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "bon",
  "darling 0.20.11",
@@ -4509,7 +4509,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-toml"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "serde",
  "tempfile",
@@ -4577,7 +4577,7 @@ dependencies = [
 
 [[package]]
 name = "example-shared-lib"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "bevy",
  "es-fluent",
@@ -4705,7 +4705,7 @@ checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
 
 [[package]]
 name = "first-example"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "es-fluent",
  "es-fluent-build",
@@ -5608,7 +5608,7 @@ dependencies = [
 
 [[package]]
 name = "gpui-example"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "es-fluent",
  "es-fluent-build",
@@ -6103,7 +6103,7 @@ dependencies = [
 
 [[package]]
 name = "iced-example"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "es-fluent",
  "es-fluent-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ publish = true
 readme = "README.md"
 repository = "https://github.com/stayhydated/es-fluent"
 rust-version = "1.88"
-version = "0.2.5"
+version = "0.2.6"
 
 [workspace.dependencies]
 anyhow = "1.0.98"
@@ -46,19 +46,19 @@ crossterm = "0.29.0"
 darling = "0.20.11"
 derive_more = "2.0.1"
 env_logger = "0.11"
-es-fluent = { default-features = false, path = "crates/es-fluent", version = "0.2.5" }
-es-fluent-build = { path = "crates/es-fluent-build", version = "0.2.5" }
-es-fluent-core = { default-features = false, path = "crates/es-fluent-core", version = "0.2.5" }
-es-fluent-derive = { path = "crates/es-fluent-derive", version = "0.2.5" }
-es-fluent-generate = { path = "crates/es-fluent-generate", version = "0.2.5" }
-es-fluent-lang = { path = "crates/es-fluent-lang", version = "0.2.5" }
-es-fluent-lang-macro = { path = "crates/es-fluent-lang-macro", version = "0.2.5" }
-es-fluent-manager-bevy = { path = "crates/es-fluent-manager-bevy", version = "0.17.5" }
-es-fluent-manager-core = { path = "crates/es-fluent-manager-core", version = "0.2.5" }
-es-fluent-manager-embedded = { path = "crates/es-fluent-manager-embedded", version = "0.2.5" }
-es-fluent-manager-macros = { path = "crates/es-fluent-manager-macros", version = "0.2.5" }
-es-fluent-sc-parser = { path = "crates/es-fluent-sc-parser", version = "0.2.5" }
-es-fluent-toml = { path = "crates/es-fluent-toml", version = "0.2.5" }
+es-fluent = { default-features = false, path = "crates/es-fluent", version = "0.2.6" }
+es-fluent-build = { path = "crates/es-fluent-build", version = "0.2.6" }
+es-fluent-core = { default-features = false, path = "crates/es-fluent-core", version = "0.2.6" }
+es-fluent-derive = { path = "crates/es-fluent-derive", version = "0.2.6" }
+es-fluent-generate = { path = "crates/es-fluent-generate", version = "0.2.6" }
+es-fluent-lang = { path = "crates/es-fluent-lang", version = "0.2.6" }
+es-fluent-lang-macro = { path = "crates/es-fluent-lang-macro", version = "0.2.6" }
+es-fluent-manager-bevy = { path = "crates/es-fluent-manager-bevy", version = "0.17.6" }
+es-fluent-manager-core = { path = "crates/es-fluent-manager-core", version = "0.2.6" }
+es-fluent-manager-embedded = { path = "crates/es-fluent-manager-embedded", version = "0.2.6" }
+es-fluent-manager-macros = { path = "crates/es-fluent-manager-macros", version = "0.2.6" }
+es-fluent-sc-parser = { path = "crates/es-fluent-sc-parser", version = "0.2.6" }
+es-fluent-toml = { path = "crates/es-fluent-toml", version = "0.2.6" }
 fluent = { version = "0.17.0" }
 fluent-bundle = "0.16.0"
 fluent-syntax = "0.11.1"

--- a/crates/es-fluent-lang-macro/CHANGELOG.md
+++ b/crates/es-fluent-lang-macro/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6](https://github.com/stayhydated/es-fluent/compare/es-fluent-lang-macro-v0.2.5...es-fluent-lang-macro-v0.2.6) - 2025-10-20
+
+### Other
+
+- release v0.2.5
+
 ## [0.2.5](https://github.com/stayhydated/es-fluent/releases/tag/es-fluent-lang-macro-v0.2.5) - 2025-10-20
 
 ### Fixed

--- a/crates/es-fluent-lang/CHANGELOG.md
+++ b/crates/es-fluent-lang/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6](https://github.com/stayhydated/es-fluent/compare/es-fluent-lang-v0.2.5...es-fluent-lang-v0.2.6) - 2025-10-20
+
+### Other
+
+- release v0.2.5
+
 ## [0.2.5](https://github.com/stayhydated/es-fluent/releases/tag/es-fluent-lang-v0.2.5) - 2025-10-20
 
 ### Fixed

--- a/crates/es-fluent-manager-bevy/CHANGELOG.md
+++ b/crates/es-fluent-manager-bevy/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.6](https://github.com/stayhydated/es-fluent/compare/es-fluent-manager-bevy-v0.17.5...es-fluent-manager-bevy-v0.17.6) - 2025-10-20
+
+### Other
+
+- updated the following local packages: es-fluent-manager-core, es-fluent, es-fluent-manager-macros
+
 ## [0.17.4](https://github.com/stayhydated/es-fluent/compare/es-fluent-manager-bevy-v0.17.3...es-fluent-manager-bevy-v0.17.4) - 2025-10-17
 
 ### Other

--- a/crates/es-fluent-manager-bevy/Cargo.toml
+++ b/crates/es-fluent-manager-bevy/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 publish.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-version = "0.17.5"
+version = "0.17.6"
 readme = "README.md"
 
 [dependencies]


### PR DESCRIPTION



## 🤖 New release

* `es-fluent-core`: 0.2.5 -> 0.2.6
* `es-fluent-derive`: 0.2.5 -> 0.2.6
* `es-fluent-manager-core`: 0.2.5 -> 0.2.6
* `es-fluent`: 0.2.5 -> 0.2.6
* `es-fluent-toml`: 0.2.5 -> 0.2.6
* `es-fluent-generate`: 0.2.5 -> 0.2.6
* `es-fluent-sc-parser`: 0.2.5 -> 0.2.6
* `es-fluent-build`: 0.2.5 -> 0.2.6
* `es-fluent-cli`: 0.2.5 -> 0.2.6
* `es-fluent-lang-macro`: 0.2.5 -> 0.2.6
* `es-fluent-lang`: 0.2.5 -> 0.2.6
* `es-fluent-manager-macros`: 0.2.5 -> 0.2.6
* `es-fluent-manager-embedded`: 0.2.5 -> 0.2.6
* `es-fluent-manager-bevy`: 0.17.5 -> 0.17.6

<details><summary><i><b>Changelog</b></i></summary><p>

## `es-fluent-core`

<blockquote>

## [0.2.4](https://github.com/stayhydated/es-fluent/compare/es-fluent-core-v0.2.3...es-fluent-core-v0.2.4) - 2025-10-17

### Other

- support struct_tuple
</blockquote>

## `es-fluent-derive`

<blockquote>

## [0.2.4](https://github.com/stayhydated/es-fluent/compare/es-fluent-derive-v0.2.3...es-fluent-derive-v0.2.4) - 2025-10-17

### Other

- support struct_tuple
</blockquote>

## `es-fluent-manager-core`

<blockquote>

## [0.2.1](https://github.com/stayhydated/es-fluent/compare/es-fluent-manager-core-v0.2.0...es-fluent-manager-core-v0.2.1) - 2025-10-12

### Other

- .
- add descriptions
</blockquote>

## `es-fluent`

<blockquote>

## [0.2.4](https://github.com/stayhydated/es-fluent/compare/es-fluent-v0.2.3...es-fluent-v0.2.4) - 2025-10-17

### Other

- mention EsFluentKv
- update first-example
- support struct_tuple
</blockquote>

## `es-fluent-toml`

<blockquote>

## [0.2.1](https://github.com/stayhydated/es-fluent/compare/es-fluent-toml-v0.2.0...es-fluent-toml-v0.2.1) - 2025-10-12

### Other

- .
</blockquote>

## `es-fluent-generate`

<blockquote>

## [0.1.1](https://github.com/stayhydated/es-fluent/compare/es-fluent-generate-v0.1.0...es-fluent-generate-v0.1.1) - 2025-07-15

### Other

- .
- place "this" variant first
- release v0.1.0
</blockquote>

## `es-fluent-sc-parser`

<blockquote>

## [0.2.1](https://github.com/stayhydated/es-fluent/compare/es-fluent-sc-parser-v0.2.0...es-fluent-sc-parser-v0.2.1) - 2025-10-12

### Other

- make clippy happy
</blockquote>

## `es-fluent-build`

<blockquote>

## [0.1.0](https://github.com/stayhydated/es-fluent/releases/tag/es-fluent-build-v0.1.0) - 2025-07-03

### Other

- .
</blockquote>

## `es-fluent-cli`

<blockquote>

## [0.1.2](https://github.com/stayhydated/es-fluent/compare/es-fluent-cli-v0.1.1...es-fluent-cli-v0.1.2) - 2025-07-15

### Other

- update Cargo.lock dependencies
</blockquote>

## `es-fluent-lang-macro`

<blockquote>

## [0.2.6](https://github.com/stayhydated/es-fluent/compare/es-fluent-lang-macro-v0.2.5...es-fluent-lang-macro-v0.2.6) - 2025-10-20

### Other

- release v0.2.5
</blockquote>

## `es-fluent-lang`

<blockquote>

## [0.2.6](https://github.com/stayhydated/es-fluent/compare/es-fluent-lang-v0.2.5...es-fluent-lang-v0.2.6) - 2025-10-20

### Other

- release v0.2.5
</blockquote>

## `es-fluent-manager-macros`

<blockquote>

## [0.2.1](https://github.com/stayhydated/es-fluent/compare/es-fluent-manager-macros-v0.2.0...es-fluent-manager-macros-v0.2.1) - 2025-10-12

### Other

- make clippy happy
- .
</blockquote>

## `es-fluent-manager-embedded`

<blockquote>

## [0.2.1](https://github.com/stayhydated/es-fluent/compare/es-fluent-manager-embedded-v0.2.0...es-fluent-manager-embedded-v0.2.1) - 2025-10-12

### Other

- .
</blockquote>

## `es-fluent-manager-bevy`

<blockquote>

## [0.17.6](https://github.com/stayhydated/es-fluent/compare/es-fluent-manager-bevy-v0.17.5...es-fluent-manager-bevy-v0.17.6) - 2025-10-20

### Other

- updated the following local packages: es-fluent-manager-core, es-fluent, es-fluent-manager-macros
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).