### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "bevy-example"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "bevy",
  "es-fluent",
@@ -3329,7 +3329,7 @@ dependencies = [
 
 [[package]]
 name = "cosmic-example"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "es-fluent",
  "es-fluent-build",
@@ -4306,7 +4306,7 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "es-fluent"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "es-fluent-derive",
  "es-fluent-manager-core",
@@ -4319,7 +4319,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-build"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "cargo_metadata",
  "es-fluent-generate",
@@ -4331,7 +4331,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-cli"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "cargo_metadata",
  "clap",
@@ -4351,7 +4351,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-core"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "bon",
  "darling 0.21.3",
@@ -4371,7 +4371,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-derive"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "darling 0.21.3",
  "es-fluent-core",
@@ -4386,7 +4386,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-generate"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "clap",
  "es-fluent-core",
@@ -4401,7 +4401,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-lang"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "es-fluent-lang-macro",
  "es-fluent-manager-core",
@@ -4413,7 +4413,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-lang-macro"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "es-fluent-toml",
  "heck 0.5.0",
@@ -4426,7 +4426,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-manager-bevy"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "bevy",
  "es-fluent",
@@ -4441,7 +4441,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-manager-core"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "fluent-bundle",
@@ -4454,7 +4454,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-manager-embedded"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "es-fluent",
  "es-fluent-manager-core",
@@ -4465,7 +4465,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-manager-macros"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "es-fluent-toml",
  "heck 0.5.0",
@@ -4476,7 +4476,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-sc-parser"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "bon",
  "darling 0.21.3",
@@ -4492,7 +4492,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-toml"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "serde",
  "tempfile",
@@ -4560,7 +4560,7 @@ dependencies = [
 
 [[package]]
 name = "example-shared-lib"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "bevy",
  "es-fluent",
@@ -4688,7 +4688,7 @@ checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
 name = "first-example"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "es-fluent",
  "es-fluent-build",
@@ -5589,7 +5589,7 @@ dependencies = [
 
 [[package]]
 name = "gpui-example"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "es-fluent",
  "es-fluent-build",
@@ -6234,7 +6234,7 @@ dependencies = [
 
 [[package]]
 name = "iced-example"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "es-fluent",
  "es-fluent-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ publish = true
 readme = "README.md"
 repository = "https://github.com/stayhydated/es-fluent"
 rust-version = "1.88"
-version = "0.2.7"
+version = "0.2.8"
 
 [workspace.dependencies]
 anyhow = "1.0.98"
@@ -46,19 +46,19 @@ crossterm = "0.29.0"
 darling = "0.21.3"
 derive_more = "2.0.1"
 env_logger = "0.11"
-es-fluent = { default-features = false, path = "crates/es-fluent", version = "0.2.7" }
-es-fluent-build = { path = "crates/es-fluent-build", version = "0.2.7" }
-es-fluent-core = { default-features = false, path = "crates/es-fluent-core", version = "0.2.7" }
-es-fluent-derive = { path = "crates/es-fluent-derive", version = "0.2.7" }
-es-fluent-generate = { path = "crates/es-fluent-generate", version = "0.2.7" }
-es-fluent-lang = { path = "crates/es-fluent-lang", version = "0.2.7" }
-es-fluent-lang-macro = { path = "crates/es-fluent-lang-macro", version = "0.2.7" }
-es-fluent-manager-bevy = { path = "crates/es-fluent-manager-bevy", version = "0.17.7" }
-es-fluent-manager-core = { path = "crates/es-fluent-manager-core", version = "0.2.7" }
-es-fluent-manager-embedded = { path = "crates/es-fluent-manager-embedded", version = "0.2.7" }
-es-fluent-manager-macros = { path = "crates/es-fluent-manager-macros", version = "0.2.7" }
-es-fluent-sc-parser = { path = "crates/es-fluent-sc-parser", version = "0.2.7" }
-es-fluent-toml = { path = "crates/es-fluent-toml", version = "0.2.7" }
+es-fluent = { default-features = false, path = "crates/es-fluent", version = "0.2.8" }
+es-fluent-build = { path = "crates/es-fluent-build", version = "0.2.8" }
+es-fluent-core = { default-features = false, path = "crates/es-fluent-core", version = "0.2.8" }
+es-fluent-derive = { path = "crates/es-fluent-derive", version = "0.2.8" }
+es-fluent-generate = { path = "crates/es-fluent-generate", version = "0.2.8" }
+es-fluent-lang = { path = "crates/es-fluent-lang", version = "0.2.8" }
+es-fluent-lang-macro = { path = "crates/es-fluent-lang-macro", version = "0.2.8" }
+es-fluent-manager-bevy = { path = "crates/es-fluent-manager-bevy", version = "0.17.8" }
+es-fluent-manager-core = { path = "crates/es-fluent-manager-core", version = "0.2.8" }
+es-fluent-manager-embedded = { path = "crates/es-fluent-manager-embedded", version = "0.2.8" }
+es-fluent-manager-macros = { path = "crates/es-fluent-manager-macros", version = "0.2.8" }
+es-fluent-sc-parser = { path = "crates/es-fluent-sc-parser", version = "0.2.8" }
+es-fluent-toml = { path = "crates/es-fluent-toml", version = "0.2.8" }
 fluent = { version = "0.17.0" }
 fluent-bundle = "0.16.0"
 fluent-syntax = "0.12"

--- a/crates/es-fluent-manager-bevy/Cargo.toml
+++ b/crates/es-fluent-manager-bevy/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 publish.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-version = "0.17.7"
+version = "0.17.8"
 readme = "README.md"
 
 [dependencies]


### PR DESCRIPTION



## 🤖 New release

* `es-fluent-core`: 0.2.7 -> 0.2.8
* `es-fluent-derive`: 0.2.7 -> 0.2.8
* `es-fluent-manager-core`: 0.2.7 -> 0.2.8
* `es-fluent`: 0.2.7 -> 0.2.8
* `es-fluent-toml`: 0.2.7 -> 0.2.8
* `es-fluent-generate`: 0.2.7 -> 0.2.8
* `es-fluent-sc-parser`: 0.2.7 -> 0.2.8
* `es-fluent-build`: 0.2.7 -> 0.2.8
* `es-fluent-cli`: 0.2.7 -> 0.2.8
* `es-fluent-lang-macro`: 0.2.7 -> 0.2.8
* `es-fluent-lang`: 0.2.7 -> 0.2.8
* `es-fluent-manager-macros`: 0.2.7 -> 0.2.8
* `es-fluent-manager-embedded`: 0.2.7 -> 0.2.8
* `es-fluent-manager-bevy`: 0.17.7 -> 0.17.8

<details><summary><i><b>Changelog</b></i></summary><p>
















</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).