### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1041,7 +1041,7 @@ dependencies = [
 
 [[package]]
 name = "bevy-example"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bevy",
  "es-fluent",
@@ -3448,7 +3448,7 @@ dependencies = [
 
 [[package]]
 name = "cosmic-example"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "es-fluent",
  "es-fluent-manager-embedded",
@@ -4424,7 +4424,7 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "es-fluent"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bon",
  "cargo_metadata",
@@ -4446,7 +4446,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-cli"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "askama",
@@ -4467,7 +4467,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bon",
  "darling 0.21.3",
@@ -4488,7 +4488,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-derive"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "darling 0.21.3",
  "es-fluent-core",
@@ -4503,7 +4503,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-generate"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "clap",
  "es-fluent-core",
@@ -4518,7 +4518,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-lang"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "es-fluent-lang-macro",
  "es-fluent-manager-core",
@@ -4530,7 +4530,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-lang-macro"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "es-fluent-toml",
  "heck 0.5.0",
@@ -4543,7 +4543,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-manager-bevy"
-version = "0.17.15"
+version = "0.17.16"
 dependencies = [
  "bevy",
  "es-fluent",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-manager-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "fluent-bundle",
@@ -4571,7 +4571,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-manager-embedded"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "es-fluent",
  "es-fluent-manager-core",
@@ -4582,7 +4582,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-manager-macros"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "es-fluent-toml",
  "heck 0.5.0",
@@ -4593,7 +4593,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-toml"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "serde",
  "tempfile",
@@ -4661,7 +4661,7 @@ dependencies = [
 
 [[package]]
 name = "example-shared-lib"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bevy",
  "es-fluent",
@@ -4787,7 +4787,7 @@ checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
 name = "first-example"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "es-fluent",
  "es-fluent-manager-embedded",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "gpui-example"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "es-fluent",
  "es-fluent-manager-embedded",
@@ -6344,7 +6344,7 @@ dependencies = [
 
 [[package]]
 name = "iced-example"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "es-fluent",
  "es-fluent-manager-embedded",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ publish = true
 readme = "README.md"
 repository = "https://github.com/stayhydated/es-fluent"
 rust-version = "1.88"
-version = "0.4.0"
+version = "0.4.1"
 
 [workspace.dependencies]
 anyhow = "1.0.98"
@@ -46,17 +46,17 @@ crossterm = "0.29.0"
 darling = "0.21.3"
 derive_more = "2.0.1"
 env_logger = "0.11"
-es-fluent = { default-features = false, path = "crates/es-fluent", version = "0.4.0" }
-es-fluent-core = { default-features = false, path = "crates/es-fluent-core", version = "0.4.0" }
-es-fluent-derive = { path = "crates/es-fluent-derive", version = "0.4.0" }
-es-fluent-generate = { path = "crates/es-fluent-generate", version = "0.4.0" }
-es-fluent-lang = { path = "crates/es-fluent-lang", version = "0.4.0" }
-es-fluent-lang-macro = { path = "crates/es-fluent-lang-macro", version = "0.4.0" }
-es-fluent-manager-bevy = { path = "crates/es-fluent-manager-bevy", version = "0.17.15" }
-es-fluent-manager-core = { path = "crates/es-fluent-manager-core", version = "0.4.0" }
-es-fluent-manager-embedded = { path = "crates/es-fluent-manager-embedded", version = "0.4.0" }
-es-fluent-manager-macros = { path = "crates/es-fluent-manager-macros", version = "0.4.0" }
-es-fluent-toml = { path = "crates/es-fluent-toml", version = "0.4.0" }
+es-fluent = { default-features = false, path = "crates/es-fluent", version = "0.4.1" }
+es-fluent-core = { default-features = false, path = "crates/es-fluent-core", version = "0.4.1" }
+es-fluent-derive = { path = "crates/es-fluent-derive", version = "0.4.1" }
+es-fluent-generate = { path = "crates/es-fluent-generate", version = "0.4.1" }
+es-fluent-lang = { path = "crates/es-fluent-lang", version = "0.4.1" }
+es-fluent-lang-macro = { path = "crates/es-fluent-lang-macro", version = "0.4.1" }
+es-fluent-manager-bevy = { path = "crates/es-fluent-manager-bevy", version = "0.17.16" }
+es-fluent-manager-core = { path = "crates/es-fluent-manager-core", version = "0.4.1" }
+es-fluent-manager-embedded = { path = "crates/es-fluent-manager-embedded", version = "0.4.1" }
+es-fluent-manager-macros = { path = "crates/es-fluent-manager-macros", version = "0.4.1" }
+es-fluent-toml = { path = "crates/es-fluent-toml", version = "0.4.1" }
 fluent = { version = "0.17.0" }
 fluent-bundle = "0.16.0"
 fluent-syntax = "0.12"

--- a/crates/es-fluent-manager-bevy/Cargo.toml
+++ b/crates/es-fluent-manager-bevy/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 publish.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-version = "0.17.15"
+version = "0.17.16"
 readme = "README.md"
 
 [dependencies]


### PR DESCRIPTION



## 🤖 New release

* `es-fluent-core`: 0.4.0 -> 0.4.1
* `es-fluent-derive`: 0.4.0 -> 0.4.1
* `es-fluent-generate`: 0.4.0 -> 0.4.1
* `es-fluent-manager-core`: 0.4.0 -> 0.4.1
* `es-fluent-toml`: 0.4.0 -> 0.4.1
* `es-fluent`: 0.4.0 -> 0.4.1
* `es-fluent-lang-macro`: 0.4.0 -> 0.4.1
* `es-fluent-lang`: 0.4.0 -> 0.4.1
* `es-fluent-cli`: 0.4.0 -> 0.4.1
* `es-fluent-manager-macros`: 0.4.0 -> 0.4.1
* `es-fluent-manager-embedded`: 0.4.0 -> 0.4.1
* `es-fluent-manager-bevy`: 0.17.15 -> 0.17.16

<details><summary><i><b>Changelog</b></i></summary><p>














</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).