### PR TITLE
chore: release v0.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1041,7 +1041,7 @@ dependencies = [
 
 [[package]]
 name = "bevy-example"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "bevy",
  "es-fluent",
@@ -3448,7 +3448,7 @@ dependencies = [
 
 [[package]]
 name = "cosmic-example"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "es-fluent",
  "es-fluent-manager-embedded",
@@ -4424,7 +4424,7 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "es-fluent"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "bon",
  "cargo_metadata",
@@ -4447,7 +4447,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-cli"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "askama",
@@ -4468,7 +4468,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-core"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "bon",
  "darling 0.21.3",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-derive"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "darling 0.21.3",
  "es-fluent-core",
@@ -4505,7 +4505,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-generate"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "clap",
  "es-fluent",
@@ -4521,7 +4521,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-lang"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "es-fluent-lang-macro",
  "es-fluent-manager-core",
@@ -4533,7 +4533,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-lang-macro"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "es-fluent-toml",
  "heck 0.5.0",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-manager-core"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "fluent-bundle",
@@ -4574,7 +4574,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-manager-embedded"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "es-fluent",
  "es-fluent-manager-core",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-manager-macros"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "es-fluent-toml",
  "heck 0.5.0",
@@ -4596,7 +4596,7 @@ dependencies = [
 
 [[package]]
 name = "es-fluent-toml"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "serde",
  "tempfile",
@@ -4664,7 +4664,7 @@ dependencies = [
 
 [[package]]
 name = "example-shared-lib"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "bevy",
  "es-fluent",
@@ -4790,7 +4790,7 @@ checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
 name = "first-example"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "es-fluent",
  "es-fluent-manager-embedded",
@@ -5695,7 +5695,7 @@ dependencies = [
 
 [[package]]
 name = "gpui-example"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "es-fluent",
  "es-fluent-manager-embedded",
@@ -6347,7 +6347,7 @@ dependencies = [
 
 [[package]]
 name = "iced-example"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "es-fluent",
  "es-fluent-manager-embedded",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ publish = true
 readme = "README.md"
 repository = "https://github.com/stayhydated/es-fluent"
 rust-version = "1.88"
-version = "0.4.2"
+version = "0.4.3"
 
 [workspace.dependencies]
 anyhow = "1.0.98"
@@ -52,17 +52,17 @@ crossterm = "0.29.0"
 darling = "0.21.3"
 derive_more = "2.0.1"
 env_logger = "0.11"
-es-fluent = { default-features = false, path = "crates/es-fluent", version = "0.4.2" }
-es-fluent-core = { default-features = false, path = "crates/es-fluent-core", version = "0.4.2" }
-es-fluent-derive = { path = "crates/es-fluent-derive", version = "0.4.2" }
-es-fluent-generate = { path = "crates/es-fluent-generate", version = "0.4.2" }
-es-fluent-lang = { path = "crates/es-fluent-lang", version = "0.4.2" }
-es-fluent-lang-macro = { path = "crates/es-fluent-lang-macro", version = "0.4.2" }
+es-fluent = { default-features = false, path = "crates/es-fluent", version = "0.4.3" }
+es-fluent-core = { default-features = false, path = "crates/es-fluent-core", version = "0.4.3" }
+es-fluent-derive = { path = "crates/es-fluent-derive", version = "0.4.3" }
+es-fluent-generate = { path = "crates/es-fluent-generate", version = "0.4.3" }
+es-fluent-lang = { path = "crates/es-fluent-lang", version = "0.4.3" }
+es-fluent-lang-macro = { path = "crates/es-fluent-lang-macro", version = "0.4.3" }
 es-fluent-manager-bevy = { path = "crates/es-fluent-manager-bevy", version = "0.17.17" }
-es-fluent-manager-core = { path = "crates/es-fluent-manager-core", version = "0.4.2" }
-es-fluent-manager-embedded = { path = "crates/es-fluent-manager-embedded", version = "0.4.2" }
-es-fluent-manager-macros = { path = "crates/es-fluent-manager-macros", version = "0.4.2" }
-es-fluent-toml = { path = "crates/es-fluent-toml", version = "0.4.2" }
+es-fluent-manager-core = { path = "crates/es-fluent-manager-core", version = "0.4.3" }
+es-fluent-manager-embedded = { path = "crates/es-fluent-manager-embedded", version = "0.4.3" }
+es-fluent-manager-macros = { path = "crates/es-fluent-manager-macros", version = "0.4.3" }
+es-fluent-toml = { path = "crates/es-fluent-toml", version = "0.4.3" }
 fluent = { version = "0.17.0" }
 fluent-bundle = "0.16.0"
 fluent-syntax = "0.12"


### PR DESCRIPTION



## 🤖 New release

* `es-fluent-core`: 0.4.2 -> 0.4.3
* `es-fluent-derive`: 0.4.2 -> 0.4.3
* `es-fluent-generate`: 0.4.2 -> 0.4.3
* `es-fluent-manager-core`: 0.4.2 -> 0.4.3
* `es-fluent-toml`: 0.4.2 -> 0.4.3
* `es-fluent`: 0.4.2 -> 0.4.3
* `es-fluent-lang-macro`: 0.4.2 -> 0.4.3
* `es-fluent-lang`: 0.4.2 -> 0.4.3
* `es-fluent-cli`: 0.4.2 -> 0.4.3
* `es-fluent-manager-macros`: 0.4.2 -> 0.4.3
* `es-fluent-manager-embedded`: 0.4.2 -> 0.4.3

<details><summary><i><b>Changelog</b></i></summary><p>













</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).